### PR TITLE
fix: update vulnerable packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
-RUN apk add apache2
+RUN apk add apache2>=2.4.41
 
 RUN apk add --update py-pip
 RUN pip install django==1.2 certifi==2019.3.9 chardet==3.0.4 idna==2.8


### PR DESCRIPTION
# Overview

- Control: NICT PR.IP-12
- Description: Vulnerable image is running as Pod
- Target resource: `de.icr.io/nogayama/abcbank-web:latest`, `au.icr.io/nogayama/abcbank-web:latest`

# Reasons

- [image contains vulnerable software package](https://cloud.ibm.com/kubernetes/registry/images/nogayama/abcbank-web/sha256:2c997c352633afa71b7e78203bf0b0ed670960a4e33ae7471c7f9ff1cd847fc2/detail/json?region=ap-north)
- Image is used by internet-facing container(s)

# Raw Evidence

```
{
  "category": "PR.IP-12",
  "description": "Vulnerable image is running as Pod",
  "targetResource": "de.icr.io/nogayama/abcbank-web:latest au.icr.io/nogayama/abcbank-web:latest",
  "targetResourceId": "6dab7bf851d8",
  "reasons": [
    {
      "label": "image-vulnerability",
      "description": "image contains vulnerable software package",
      "url": "https://cloud.ibm.com/kubernetes/registry/images/nogayama/abcbank-web/sha256:2c997c352633afa71b7e78203bf0b0ed670960a4e33ae7471c7f9ff1cd847fc2/detail/json?region=ap-north"
    },
    {
      "label": "internet-facing",
      "description": "Image is used by internet-facing container(s)"
    }
  ],
  "action": "[Create Pull Request to fix vulnerability](#)",
  "relatedResources": [
    "cluster2/abcbank-web-7fx8jsick3-93mdu/abcbank-web"
  ],
  "issue_id": 505
}
```
