### PR TITLE
Title: Fix os package vulnerability 'apache2'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o app .
 FROM alpine:latest  
 RUN apk --no-cache add ca-certificates
 RUN apk add apache2
+RUN apk add apache2>=2.4.41
 
 RUN apk add --update py-pip
 RUN pip install django==1.2 certifi==2019.3.9 chardet==3.0.4 idna==2.8


### PR DESCRIPTION
Vulnerable packages are running on multiple containers on pods on clusters.

### Affected resources:

- Buildstate: FromLine6
	- Image: `de.icr.io/nogayama/abcbank-web:latest`
		- Cluster: cluster1
			- pod: `nogayama/abcbank-web:latest` (**Internet facing**)
				- container `nogayama/abcbank-web:latest`
					- Package Vulnerability: apache2 [Link](https://cloud.ibm.com/kubernetes/registry/images/nogayama/abcbank-web/sha256:2c997c352633afa71b7e78203bf0b0ed670960a4e33ae7471c7f9ff1cd847fc2/detail/json?region=ap-north)

	- Image: `au.icr.io/nogayama/abcbank-web:latest`
		- Cluster: cluster2
			- pod: `nogayama/abcbank-web:latest` (**Internet facing**)
				- container `nogayama/abcbank-web:latest`
					- Package Vulnerability: apache2 [Link](https://cloud.ibm.com/kubernetes/registry/images/nogayama/abcbank-web/sha256:2c997c352633afa71b7e78203bf0b0ed670960a4e33ae7471c7f9ff1cd847fc2/detail/json?region=ap-north)